### PR TITLE
Fix ユニットの最初の特殊能力表示。

### DIFF
--- a/SRC.Sharp/SRCTestBlazor/Shared/UnitDataView.razor
+++ b/SRC.Sharp/SRCTestBlazor/Shared/UnitDataView.razor
@@ -70,8 +70,7 @@
                     </div>
                 </div>
             </div>
-            @* 先頭は『特殊能力』表示用なので飛ばす *@
-            <FeatureDataListView Features="@Data.Features.Skip(1)"></FeatureDataListView>
+            <FeatureDataListView Features="@Data.Features"></FeatureDataListView>
         </div>
         @if (Data.Weapons.Any())
         {


### PR DESCRIPTION
Skipしなきゃいけなかったのがバグだったのでは？