### PR TITLE
パイロット特殊能力の能力値修正を多分適用。

### DIFF
--- a/SRC.Sharp/SRCCore/Lib/GeneralLib.cs
+++ b/SRC.Sharp/SRCCore/Lib/GeneralLib.cs
@@ -138,7 +138,7 @@ namespace SRCCore.Lib
             }
 
             var l = ToL(list);
-            if (l.Count <= idx)
+            if (l.Count >= idx)
             {
                 return l[idx - 1];
             }
@@ -345,153 +345,11 @@ namespace SRCCore.Lib
             return hasError ? -1 : larray.Length;
         }
 
-        //        // リスト list から idx 番目以降の全要素を返す (括弧を考慮)
-        //        public static string ListTail(string list, int idx)
-        //        {
-        //            string ListTailRet = default;
-        //            int n, i, ch;
-        //            int list_len, paren = default;
-        //            bool in_single_quote = default, in_double_quote = default;
-
-        //            // idxが正の数でなければ空文字列を返す
-        //            if (idx < 1)
-        //            {
-        //                return ListTailRet;
-        //            }
-
-        //            list_len = Strings.Len(list);
-
-        //            // idx番目の要素まで読み飛ばす
-        //            n = 0;
-        //            i = 0;
-        //            while (true)
-        //            {
-        //                // 空白を読み飛ばす
-        //                while (true)
-        //                {
-        //                    i = (i + 1);
-
-        //                    // 文字列の終り？
-        //                    if (i > list_len)
-        //                    {
-        //                        return ListTailRet;
-        //                    }
-
-        //                    // 次の文字
-        //                    ch = Strings.Asc(Strings.Mid(list, i, 1));
-
-        //                    // 空白でない？
-        //                    switch (ch)
-        //                    {
-        //                        // スキップ
-        //                        case 9:
-        //                        case 32:
-        //                            {
-        //                                break;
-        //                            }
-
-        //                        default:
-        //                            {
-        //                                break;
-        //                            }
-        //                    }
-        //                }
-
-        //                // 要素数を１つ増やす
-        //                n = (n + 1);
-
-        //                // 求める要素？
-        //                if (n == idx)
-        //                {
-        //                    break;
-        //                }
-
-        //                // 要素を読み飛ばす
-        //                while (true)
-        //                {
-        //                    if (in_single_quote)
-        //                    {
-        //                        if (ch == 96) // "`"
-        //                        {
-        //                            in_single_quote = false;
-        //                        }
-        //                    }
-        //                    else if (in_double_quote)
-        //                    {
-        //                        if (ch == 34) // """"
-        //                        {
-        //                            in_double_quote = false;
-        //                        }
-        //                    }
-        //                    else
-        //                    {
-        //                        switch (ch)
-        //                        {
-        //                            case 40:
-        //                            case 91: // "(", "["
-        //                                {
-        //                                    paren = (paren + 1);
-        //                                    break;
-        //                                }
-
-        //                            case 41:
-        //                            case 93: // ")", "]"
-        //                                {
-        //                                    paren = (paren - 1);
-        //                                    if (paren < 0)
-        //                                    {
-        //                                        // 括弧の対応が取れていない
-        //                                        return ListTailRet;
-        //                                    }
-
-        //                                    break;
-        //                                }
-
-        //                            case 96: // "`"
-        //                                {
-        //                                    in_single_quote = true;
-        //                                    break;
-        //                                }
-
-        //                            case 34: // """"
-        //                                {
-        //                                    in_double_quote = true;
-        //                                    break;
-        //                                }
-        //                        }
-        //                    }
-
-        //                    i = (i + 1);
-
-        //                    // 文字列の終り？
-        //                    if (i > list_len)
-        //                    {
-        //                        return ListTailRet;
-        //                    }
-
-        //                    // 次の文字
-        //                    ch = Strings.Asc(Strings.Mid(list, i, 1));
-
-        //                    // 要素の末尾か判定
-        //                    if (!in_single_quote & !in_double_quote & paren == 0)
-        //                    {
-        //                        // 空白？
-        //                        switch (ch)
-        //                        {
-        //                            case 9:
-        //                            case 32:
-        //                                {
-        //                                    break;
-        //                                }
-        //                        }
-        //                    }
-        //                }
-        //            }
-
-        //            ListTailRet = Strings.Mid(list, i);
-        //            return ListTailRet;
-        //        }
-
+        // リスト list から idx 番目以降の全要素を返す (括弧を考慮)
+        public static string ListTail(string list, int idx)
+        {
+            return idx > 1 ? string.Join(" ", ToList(list ?? "").Skip(idx - 1)) : "";
+        }
 
         //        // タブを考慮したTrim
         //        // UPGRADE_NOTE: str は str_Renamed にアップグレードされました。 詳細については、'ms-help://MS.VSCC.v90/dv_commoner/local/redirect.htm?keyword="A9E4979A-37FA-4718-9994-97DD76ED70A7"' をクリックしてください。

--- a/SRC.Sharp/SRCCore/Models/PilotData.cs
+++ b/SRC.Sharp/SRCCore/Models/PilotData.cs
@@ -74,8 +74,11 @@ namespace SRCCore.Models
         public string Raw = "";
         public string DataComment = "";
 
-        public PilotData() : base()
+        private SRC SRC;
+        public PilotData(SRC src)
         {
+            SRC = src;
+
             SpecialPowers = new List<PilotDataSpecialPower>();
             colSkill = new SrcCollection<SkillData>();
             colFeature = new SrcCollection<FeatureData>();

--- a/SRC.Sharp/SRCCore/Models/PilotDataList.cs
+++ b/SRC.Sharp/SRCCore/Models/PilotDataList.cs
@@ -33,7 +33,7 @@ namespace SRCCore.Models
         }
         private void AddDummyData()
         {
-            var pd = new PilotData();
+            var pd = new PilotData(SRC);
 
             // ユニットステータスコマンドの無人ユニット用
             pd.Name = "ステータス表示用ダミーパイロット(ザコ)";
@@ -52,12 +52,10 @@ namespace SRCCore.Models
         // パイロットデータリストにデータを追加
         public PilotData Add(string pname)
         {
-            PilotData AddRet = default;
-            var new_pilot_data = new PilotData();
+            var new_pilot_data = new PilotData(SRC);
             new_pilot_data.Name = pname;
             colPilotDataList.Add(new_pilot_data, pname);
-            AddRet = new_pilot_data;
-            return AddRet;
+            return new_pilot_data;
         }
 
         // パイロットデータリストに登録されているデータの総数

--- a/SRC.Sharp/SRCCore/Pilots/Pilot.cs
+++ b/SRC.Sharp/SRCCore/Pilots/Pilot.cs
@@ -21,8 +21,7 @@ namespace SRCCore.Pilots
             SRC = src;
             Data = data;
 
-            // Impl
-            //Update();
+            Update();
         }
 
         // パイロットデータへのポインタ

--- a/SRC.Sharp/SRCCore/Pilots/Pilot.skill.cs
+++ b/SRC.Sharp/SRCCore/Pilots/Pilot.skill.cs
@@ -124,133 +124,117 @@ namespace SRCCore.Pilots
         // 特殊能力が使用不能の場合はレベル 0
         public double SkillLevel(string Index, string ref_mode = "")
         {
-            return 0d;
-            // TODO Impl
-            //    double SkillLevelRet = default;
-            //    string sname;
-            //    SkillData sd;
-            //    ;
-            //    /* Cannot convert OnErrorGoToStatementSyntax, CONVERSION ERROR: Conversion for OnErrorGoToLabelStatement not implemented, please report this issue in 'On Error GoTo ErrorHandler' at character 49058
+            SkillData sd = colSkill[Index];
+            string sname = sd?.Name;
+            double SkillLevelRet = sd?.Level ?? 0;
+            if (SkillLevelRet == Constants.DEFAULT_LEVEL)
+            {
+                SkillLevelRet = 1d;
+            }
 
+            if (string.IsNullOrEmpty(sname))
+            {
+                // XXX これ引数に数字で参照指定してた場合向けか？
+                if (Information.IsNumeric(Index))
+                {
+                    return SkillLevelRet;
+                }
+                else
+                {
+                    sname = Conversions.ToString(Index);
+                }
+            }
 
-            //    Input:
+            if (ref_mode == "修正値")
+            {
+                SkillLevelRet = 0d;
+            }
+            else if (ref_mode == "基本値")
+            {
+                return SkillLevelRet;
+            }
 
-            //            On Error GoTo ErrorHandler
+            // 重複可能な能力は特殊能力付加で置き換えられことはない
+            switch (sname ?? "")
+            {
+                case "ハンター":
+                case "ＳＰ消費減少":
+                case "スペシャルパワー自動発動":
+                    {
+                        if (Information.IsNumeric(Index))
+                        {
+                            return SkillLevelRet;
+                        }
 
-            //     */
-            //    sd = (SkillData)colSkill[Index];
-            //    sname = sd.Name;
-            //    SkillLevelRet = sd.Level;
-            //    if (SkillLevelRet == Constants.DEFAULT_LEVEL)
-            //    {
-            //        SkillLevelRet = 1d;
-            //    }
+                        break;
+                    }
+            }
 
-            //ErrorHandler:
-            //    ;
-            //    if (string.IsNullOrEmpty(sname))
-            //    {
-            //        if (Information.IsNumeric(Index))
-            //        {
-            //            return SkillLevelRet;
-            //        }
-            //        else
-            //        {
-            //            // UPGRADE_WARNING: オブジェクト Index の既定プロパティを解決できませんでした。 詳細については、'ms-help://MS.VSCC.v90/dv_commoner/local/redirect.htm?keyword="6A50421D-15FE-4896-8A1B-2EC21E9037B2"' をクリックしてください。
-            //            sname = Conversions.ToString(Index);
-            //        }
-            //    }
+            // 特殊能力付加＆強化による修正
+            if (Unit is null)
+            {
+                return SkillLevelRet;
+            }
 
-            //    if (ref_mode == "修正値")
-            //    {
-            //        SkillLevelRet = 0d;
-            //    }
-            //    else if (ref_mode == "基本値")
-            //    {
-            //        return SkillLevelRet;
-            //    }
+            {
+                // TODO Impl
+                //if (Unit.CountCondition() == 0)
+                //{
+                //    return SkillLevelRet;
+                //}
 
-            //    // 重複可能な能力は特殊能力付加で置き換えられことはない
-            //    switch (sname ?? "")
-            //    {
-            //        case "ハンター":
-            //        case "ＳＰ消費減少":
-            //        case "スペシャルパワー自動発動":
-            //            {
-            //                if (Information.IsNumeric(Index))
-            //                {
-            //                    return SkillLevelRet;
-            //                }
+                //if (Unit.CountPilot() == 0)
+                //{
+                //    return SkillLevelRet;
+                //}
 
-            //                break;
-            //            }
-            //    }
+                //object argIndex1 = 1;
+                //object argIndex2 = 1;
+                //if (!ReferenceEquals(this, Unit.MainPilot()) & !ReferenceEquals(this, Unit.Pilot(argIndex2)))
+                //{
+                //    return SkillLevelRet;
+                //}
 
-            //    // 特殊能力付加＆強化による修正
-            //    if (Unit is null)
-            //    {
-            //        return SkillLevelRet;
-            //    }
+                //bool localIsConditionSatisfied() { object argIndex1 = sname + "付加２"; var ret = Unit.IsConditionSatisfied(argIndex1); return ret; }
 
-            //    {
-            //        var withBlock = Unit;
-            //        if (withBlock.CountCondition() == 0)
-            //        {
-            //            return SkillLevelRet;
-            //        }
+                //object argIndex5 = sname + "付加";
+                //if (Unit.IsConditionSatisfied(argIndex5))
+                //{
+                //    object argIndex3 = sname + "付加";
+                //    SkillLevelRet = Unit.ConditionLevel(argIndex3);
+                //    if (SkillLevelRet == Constants.DEFAULT_LEVEL)
+                //    {
+                //        SkillLevelRet = 1d;
+                //    }
+                //}
+                //else if (localIsConditionSatisfied())
+                //{
+                //    object argIndex4 = sname + "付加２";
+                //    SkillLevelRet = Unit.ConditionLevel(argIndex4);
+                //    if (SkillLevelRet == Constants.DEFAULT_LEVEL)
+                //    {
+                //        SkillLevelRet = 1d;
+                //    }
+                //}
 
-            //        if (withBlock.CountPilot() == 0)
-            //        {
-            //            return SkillLevelRet;
-            //        }
+                //object argIndex6 = sname + "強化";
+                //if (Unit.IsConditionSatisfied(argIndex6))
+                //{
+                //    double localConditionLevel() { object argIndex1 = sname + "強化"; var ret = Unit.ConditionLevel(argIndex1); return ret; }
 
-            //        object argIndex1 = 1;
-            //        object argIndex2 = 1;
-            //        if (!ReferenceEquals(this, withBlock.MainPilot()) & !ReferenceEquals(this, withBlock.Pilot(argIndex2)))
-            //        {
-            //            return SkillLevelRet;
-            //        }
+                //    SkillLevelRet = SkillLevelRet + localConditionLevel();
+                //}
 
-            //        bool localIsConditionSatisfied() { object argIndex1 = sname + "付加２"; var ret = withBlock.IsConditionSatisfied(argIndex1); return ret; }
+                //object argIndex7 = sname + "強化２";
+                //if (Unit.IsConditionSatisfied(argIndex7))
+                //{
+                //    double localConditionLevel1() { object argIndex1 = sname + "強化２"; var ret = Unit.ConditionLevel(argIndex1); return ret; }
 
-            //        object argIndex5 = sname + "付加";
-            //        if (withBlock.IsConditionSatisfied(argIndex5))
-            //        {
-            //            object argIndex3 = sname + "付加";
-            //            SkillLevelRet = withBlock.ConditionLevel(argIndex3);
-            //            if (SkillLevelRet == Constants.DEFAULT_LEVEL)
-            //            {
-            //                SkillLevelRet = 1d;
-            //            }
-            //        }
-            //        else if (localIsConditionSatisfied())
-            //        {
-            //            object argIndex4 = sname + "付加２";
-            //            SkillLevelRet = withBlock.ConditionLevel(argIndex4);
-            //            if (SkillLevelRet == Constants.DEFAULT_LEVEL)
-            //            {
-            //                SkillLevelRet = 1d;
-            //            }
-            //        }
+                //    SkillLevelRet = SkillLevelRet + localConditionLevel1();
+                //}
+            }
 
-            //        object argIndex6 = sname + "強化";
-            //        if (withBlock.IsConditionSatisfied(argIndex6))
-            //        {
-            //            double localConditionLevel() { object argIndex1 = sname + "強化"; var ret = withBlock.ConditionLevel(argIndex1); return ret; }
-
-            //            SkillLevelRet = SkillLevelRet + localConditionLevel();
-            //        }
-
-            //        object argIndex7 = sname + "強化２";
-            //        if (withBlock.IsConditionSatisfied(argIndex7))
-            //        {
-            //            double localConditionLevel1() { object argIndex1 = sname + "強化２"; var ret = withBlock.ConditionLevel(argIndex1); return ret; }
-
-            //            SkillLevelRet = SkillLevelRet + localConditionLevel1();
-            //        }
-            //    }
-
-            //    return SkillLevelRet;
+            return SkillLevelRet;
         }
 
         // 特殊能力 Index にレベル指定がなされているか判定

--- a/SRC.Sharp/SRCCore/Pilots/Pilot.status.cs
+++ b/SRC.Sharp/SRCCore/Pilots/Pilot.status.cs
@@ -7,6 +7,8 @@ using SRCCore.Models;
 using SRCCore.Units;
 using SRCCore.VB;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace SRCCore.Pilots
 {
@@ -28,60 +30,40 @@ namespace SRCCore.Pilots
             // 以前の一覧を削除
             colSkill.Clear();
 
-            //    // パイロットデータを参照しながら使用可能な特殊能力を検索
-            //    skill_num = 0;
-            //    foreach (SkillData currentSd in Data.colSkill)
-            //    {
-            //        sd = currentSd;
-            //        {
-            //            var withBlock1 = sd;
-            //            if (Level >= withBlock1.NecessaryLevel)
-            //            {
-            //                // 既に登録済み？
-            //                if (withBlock1.Name == "ＳＰ消費減少" | withBlock1.Name == "スペシャルパワー自動発動" | withBlock1.Name == "ハンター")
-            //                {
-            //                    // これらの特殊能力は同種の能力を複数持つことが出来る
-            //                    var loopTo1 = skill_num;
-            //                    for (i = 1; i <= loopTo1; i++)
-            //                    {
-            //                        if ((withBlock1.Name ?? "") == (skill_name[i] ?? ""))
-            //                        {
-            //                            if ((withBlock1.StrData ?? "") == (skill_data[i].StrData ?? ""))
-            //                            {
-            //                                // ただしデータ指定まで同一であれば同じ能力と見なす
-            //                                break;
-            //                            }
-            //                        }
-            //                    }
-            //                }
-            //                else
-            //                {
-            //                    var loopTo2 = skill_num;
-            //                    for (i = 1; i <= loopTo2; i++)
-            //                    {
-            //                        if ((withBlock1.Name ?? "") == (skill_name[i] ?? ""))
-            //                        {
-            //                            break;
-            //                        }
-            //                    }
-            //                }
+            // パイロットデータを参照しながら使用可能な特殊能力を検索
+            var effectiveSkills = new List<SkillData>();
+            foreach (SkillData sd in Data.Skills)
+            {
+                if (Level >= sd.NecessaryLevel)
+                {
+                    SkillData registerd;
+                    // 既に登録済み？
+                    if (sd.Name == "ＳＰ消費減少" | sd.Name == "スペシャルパワー自動発動" | sd.Name == "ハンター")
+                    {
+                        // これらの特殊能力は同種の能力を複数持つことが出来る
+                        // ただしデータ指定まで同一であれば同じ能力と見なす
+                        registerd = effectiveSkills.FirstOrDefault(x => x.Name == sd.Name && x.StrData == x.StrData);
+                    }
+                    else
+                    {
+                        registerd = effectiveSkills.FirstOrDefault(x => x.Name == sd.Name);
+                    }
 
-            //                if (i > skill_num)
-            //                {
-            //                    // 未登録
-            //                    skill_num = (skill_num + 1);
-            //                    skill_name[skill_num] = withBlock1.Name;
-            //                    skill_data[skill_num] = sd;
-            //                }
-            //                else if (withBlock1.NecessaryLevel > skill_data[i].NecessaryLevel)
-            //                {
-            //                    // 登録済みである場合は習得レベルが高いものを優先
-            //                    skill_data[i] = sd;
-            //                }
-            //            }
-            //        }
-            //    }
+                    if (registerd == null)
+                    {
+                        // 未登録
+                        effectiveSkills.Add(sd);
+                    }
+                    else if (sd.NecessaryLevel > registerd.NecessaryLevel)
+                    {
+                        // 登録済みである場合は習得レベルが高いものを優先
+                        effectiveSkills.Remove(registerd);
+                        effectiveSkills.Add(sd);
+                    }
+                }
+            }
 
+            // TODO Impl
             //    // SetSkillコマンドで付加された特殊能力を検索
             //    string sname, alist, sdata;
             //    string buf;
@@ -179,50 +161,33 @@ namespace SRCCore.Pilots
             //        }
             //    }
 
-            //    // 使用可能な特殊能力を登録
-            //    {
-            //        var withBlock2 = colSkill;
-            //        var loopTo7 = skill_num;
-            //        for (i = 1; i <= loopTo7; i++)
-            //        {
-            //            if (skill_data[i] is object)
-            //            {
-            //                switch (skill_name[i] ?? "")
-            //                {
-            //                    case "ＳＰ消費減少":
-            //                    case "スペシャルパワー自動発動":
-            //                    case "ハンター":
-            //                        {
-            //                            var loopTo8 = (i - 1);
-            //                            for (j = 1; j <= loopTo8; j++)
-            //                            {
-            //                                if ((skill_name[i] ?? "") == (skill_name[j] ?? ""))
-            //                                {
-            //                                    break;
-            //                                }
-            //                            }
+            // 使用可能な特殊能力を登録
+            {
+                var i = 0;
+                foreach (var sd in effectiveSkills)
+                {
+                    i++;
+                    switch (sd.Name ?? "")
+                    {
+                        case "ＳＰ消費減少":
+                        case "スペシャルパワー自動発動":
+                        case "ハンター":
+                            if (colSkill.ContainsKey(sd.Name))
+                            {
+                                colSkill.Add(sd, sd.Name + ":" + i);
+                            }
+                            else
+                            {
+                                colSkill.Add(sd, sd.Name);
+                            }
+                            break;
 
-            //                            if (j >= i)
-            //                            {
-            //                                withBlock2.Add(skill_data[i], skill_name[i]);
-            //                            }
-            //                            else
-            //                            {
-            //                                withBlock2.Add(skill_data[i], skill_name[i] + ":" + SrcFormatter.Format(i));
-            //                            }
-
-            //                            break;
-            //                        }
-
-            //                    default:
-            //                        {
-            //                            withBlock2.Add(skill_data[i], skill_name[i]);
-            //                            break;
-            //                        }
-            //                }
-            //            }
-            //        }
-            //    }
+                        default:
+                            colSkill.Add(sd, sd.Name);
+                            break;
+                    }
+                }
+            }
             #endregion
 
             // これから下は能力値の計算

--- a/SRC.Sharp/SRCCore/Pilots/Pilot.status.cs
+++ b/SRC.Sharp/SRCCore/Pilots/Pilot.status.cs
@@ -290,58 +290,48 @@ namespace SRCCore.Pilots
             IntuitionMod = 0;
 
             #region パイロット用特殊能力による修正
-            //    object argIndex23 = "超感覚";
-            //    string argref_mode21 = "";
-            //    lv = SkillLevel(argIndex23, ref_mode: argref_mode21);
-            //    if (lv > 0d)
-            //    {
-            //        HitMod = (HitMod + 2d * lv + 3d);
-            //        DodgeMod = (DodgeMod + 2d * lv + 3d);
-            //    }
+            lv = SkillLevel("超感覚", "");
+            if (lv > 0d)
+            {
+                HitMod = (int)(HitMod + 2d * lv + 3d);
+                DodgeMod = (int)(DodgeMod + 2d * lv + 3d);
+            }
 
-            //    object argIndex24 = "知覚強化";
-            //    string argref_mode22 = "";
-            //    lv = SkillLevel(argIndex24, ref_mode: argref_mode22);
-            //    if (lv > 0d)
-            //    {
-            //        HitMod = (HitMod + 2d * lv + 3d);
-            //        DodgeMod = (DodgeMod + 2d * lv + 3d);
-            //    }
+            lv = SkillLevel("知覚強化", "");
+            if (lv > 0d)
+            {
+                HitMod = (int)(HitMod + 2d * lv + 3d);
+                DodgeMod = (int)(DodgeMod + 2d * lv + 3d);
+            }
 
-            //    object argIndex25 = "念力";
-            //    string argref_mode23 = "";
-            //    lv = SkillLevel(argIndex25, ref_mode: argref_mode23);
-            //    if (lv > 0d)
-            //    {
-            //        HitMod = (HitMod + 2d * lv + 3d);
-            //        DodgeMod = (DodgeMod + 2d * lv + 3d);
-            //    }
+            lv = SkillLevel("念力", "");
+            if (lv > 0d)
+            {
+                HitMod = (int)(HitMod + 2d * lv + 3d);
+                DodgeMod = (int)(DodgeMod + 2d * lv + 3d);
+            }
 
-            //    object argIndex26 = "超反応";
-            //    string argref_mode24 = "";
-            //    lv = SkillLevel(argIndex26, ref_mode: argref_mode24);
-            //    HitMod = (HitMod + 2d * lv);
-            //    DodgeMod = (DodgeMod + 2d * lv);
-            //    string argsname = "サイボーグ";
-            //    if (IsSkillAvailable(argsname))
-            //    {
-            //        HitMod = (HitMod + 5);
-            //        DodgeMod = (DodgeMod + 5);
-            //    }
+            lv = SkillLevel("超反応", "");
+            HitMod = (int)(HitMod + 2d * lv);
+            DodgeMod = (int)(DodgeMod + 2d * lv);
 
-            //    string argsname1 = "悟り";
-            //    if (IsSkillAvailable(argsname1))
-            //    {
-            //        HitMod = (HitMod + 10);
-            //        DodgeMod = (DodgeMod + 10);
-            //    }
+            if (IsSkillAvailable("サイボーグ"))
+            {
+                HitMod = (HitMod + 5);
+                DodgeMod = (DodgeMod + 5);
+            }
 
-            //    string argsname2 = "超能力";
-            //    if (IsSkillAvailable(argsname2))
-            //    {
-            //        HitMod = (HitMod + 5);
-            //        DodgeMod = (DodgeMod + 5);
-            //    }
+            if (IsSkillAvailable("悟り"))
+            {
+                HitMod = (HitMod + 10);
+                DodgeMod = (DodgeMod + 10);
+            }
+
+            if (IsSkillAvailable("超能力"))
+            {
+                HitMod = (HitMod + 5);
+                DodgeMod = (DodgeMod + 5);
+            }
             #endregion
 
             #region これから下はユニットによる修正値の計算


### PR DESCRIPTION
#112

が72％なのが59％になっているので差が13%。

0079アムロが146, 160, 154, 160, 173, 170, 普通 -> 154+170 = 324
CCAアムロが146, 165, 159, 165, 188, 169, 普通 -> 159+169 = 328 
NTレベル3は5+2+2で9、328 + 9 = 337

337 - 324 = 13

なのでまぁ合ってそう。

![image](https://user-images.githubusercontent.com/4744735/111850355-68e41100-8953-11eb-8aa8-c8b4553ea98a.png)
