### PR TITLE
Fix Message margin

### DIFF
--- a/SRC.Sharp/SRCSharpForm/Extensions/GraphicsExtension.cs
+++ b/SRC.Sharp/SRCSharpForm/Extensions/GraphicsExtension.cs
@@ -14,6 +14,7 @@ namespace SRCSharpForm.Extensions
                 // https://github.com/dotnet/runtime/blob/33033b22eccf50550451387ac8927ad1b5f17768/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.cs#L1565
                 // 最終的には GdipMeasureString に移譲されていて余白の付与量が具体的にどうなのかサッとは分からなかった。
                 // 雰囲気デフォルトっぽい文字サイズの 0.5em 位な感じはするのでそのくらいにしておく。
+                // XXX 終端空白以外でも文字によって余白調整されていそう
                 size.Width -= RefFont.Size / 2f;
             }
             return size;

--- a/SRC.Sharp/SRCSharpForm/Extensions/GraphicsExtension.cs
+++ b/SRC.Sharp/SRCSharpForm/Extensions/GraphicsExtension.cs
@@ -8,7 +8,7 @@ namespace SRCSharpForm.Extensions
         public static SizeF MeasureStringWithoutRightMargin(this Graphics g, string str, Font font)
         {
             var size = g.MeasureString(str, font);
-            if (str.Length == str.TrimEnd().Length)
+            if (!string.IsNullOrEmpty(str) && str.Length == str.TrimEnd().Length)
             {
                 // 終端が空白文字列ではない場合はMeasureが付与する余白をカットする
                 // https://github.com/dotnet/runtime/blob/33033b22eccf50550451387ac8927ad1b5f17768/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.cs#L1565
@@ -16,7 +16,6 @@ namespace SRCSharpForm.Extensions
                 // 雰囲気デフォルトっぽい文字サイズの 0.5em 位な感じはするのでそのくらいにしておく。
                 size.Width -= RefFont.Size / 2f;
             }
-
             return size;
         }
     }

--- a/SRC.Sharp/SRCSharpForm/SRCSharpFormGUI.draw.cs
+++ b/SRC.Sharp/SRCSharpForm/SRCSharpFormGUI.draw.cs
@@ -1161,7 +1161,7 @@ namespace SRCSharpForm
                 var prev_cx = currentDrawStringPoint.X;
                 float tx = currentDrawStringPoint.X;
                 float ty = currentDrawStringPoint.Y;
-                var msgSize = g.MeasureString(msg, currentDrawFont);
+                var msgSize = g.MeasureStringWithoutRightMargin(msg, currentDrawFont);
                 // 書き込み先の座標を求める
                 if (HCentering)
                 {
@@ -1251,7 +1251,7 @@ namespace SRCSharpForm
                 var font = SRC.BattleAnimation ? battleAnimeFont : sysFont;
 
                 // メッセージの書き込み
-                var msgSize = g.MeasureString(msg, font);
+                var msgSize = g.MeasureStringWithoutRightMargin(msg, font);
                 var tx = MapToPixelX(X) + (frmMain.MapCellPx - msgSize.Width) / 2 - 1;
                 var ty = MapToPixelY(Y + 1) - msgSize.Height;
 
@@ -1274,7 +1274,7 @@ namespace SRCSharpForm
         public SizeF MeasureString(string msg)
         {
             using var g = Graphics.FromImage(MainForm.picBack.Image);
-            return g.MeasureString(msg, currentDrawFont);
+            return g.MeasureStringWithoutRightMargin(msg, currentDrawFont);
         }
     }
 }

--- a/SRC.Sharp/SRCSharpForm/SRCSharpFormGUI.message.cs
+++ b/SRC.Sharp/SRCSharpForm/SRCSharpFormGUI.message.cs
@@ -1691,7 +1691,7 @@ namespace SRCSharpForm
             var ret = Strings.InStr(msg, "<");
             if (ret == 0)
             {
-                return g.MeasureString(msg, font);
+                return g.MeasureStringWithoutRightMargin(msg, font);
             }
 
             var buf = "";
@@ -1716,7 +1716,7 @@ namespace SRCSharpForm
             buf = buf + msg;
 
             // タグ抜きメッセージのピクセル幅を計算
-            return g.MeasureString(buf, font);
+            return g.MeasureStringWithoutRightMargin(buf, font);
         }
 
         public void DisplayBattleMessage(string pname, string msg, string msg_mode)


### PR DESCRIPTION
#155

#156

Before
![image](https://user-images.githubusercontent.com/4744735/117536483-3a6ee200-b036-11eb-877d-7cc3579b5b57.png)

After
![image](https://user-images.githubusercontent.com/4744735/117536478-2e832000-b036-11eb-8ea0-aca321789728.png)

多分空白以外のカーニングもあるなこれ。むずいわ。
