### PR TITLE
FIx パイロット画像の背景抜けてる

### DIFF
--- a/SRC.Sharp/SRCSharpForm/Forms/Main.guistatus.cs
+++ b/SRC.Sharp/SRCSharpForm/Forms/Main.guistatus.cs
@@ -315,7 +315,7 @@ namespace SRCSharpForm
                         //    }
                         //}
                         // 画像ファイルを読み込んで表示
-                        var image = imageBuffer.GetTransparent(fname);
+                        var image = imageBuffer.Get(fname);
                         picFace.Image = image;
                     }
                     // パイロット愛称


### PR DESCRIPTION
fix #172
>パイロット画像の背景抜けてる（抜かないようにした気がするんだけどな）（ステータスウィンドウだけ？）