### PR TITLE
Update Audio Library

### DIFF
--- a/SRC.Sharp/SRCSharpForm/Properties/launchSettings.json
+++ b/SRC.Sharp/SRCSharpForm/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "SRCSharpForm": {
+      "commandName": "Project",
+      "nativeDebugging": false
+    }
+  }
+}

--- a/SRC.Sharp/SRCSharpForm/SRCSharpForm.csproj
+++ b/SRC.Sharp/SRCSharpForm/SRCSharpForm.csproj
@@ -13,10 +13,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Melanchall.DryWetMidi" Version="5.2.0" />
+		<PackageReference Include="Melanchall.DryWetMidi" Version="5.2.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
-		<PackageReference Include="NAudio" Version="2.0.0" />
+		<PackageReference Include="NAudio" Version="2.0.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 		<PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
 		<PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />


### PR DESCRIPTION
https://github.com/melanchall/drywetmidi/releases/tag/v5.2.1
https://github.com/naudio/NAudio/pull/798

> Workaround access violation crash added in .NET 5.0.7 when marshalling non-sealed classes

Fix #321

ライブラリアップデートはBotがいい感じにお知らせしてくれると油断していた。
動いてるのセキュリティアラートだけか？