### PR TITLE
依存パッケージを最新バージョンにアップデート

### DIFF
--- a/SRC.Sharp/SRCCore/SRCCore.csproj
+++ b/SRC.Sharp/SRCCore/SRCCore.csproj
@@ -20,14 +20,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="ShiftJISExtension" Version="1.1.0" />
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
-    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="10.0.3" />
   </ItemGroup>
 
 </Project>

--- a/SRC.Sharp/SRCDataLinter/SRCDataLinter.csproj
+++ b/SRC.Sharp/SRCDataLinter/SRCDataLinter.csproj
@@ -11,7 +11,7 @@
     <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="ShiftJISExtension" Version="1.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/SRC.Sharp/SRCSharpForm/SRCSharpForm.csproj
+++ b/SRC.Sharp/SRCSharpForm/SRCSharpForm.csproj
@@ -15,15 +15,15 @@
 
 	<ItemGroup>
 		<PackageReference Include="Melanchall.DryWetMidi" Version="5.2.1" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.3" />
 		<PackageReference Include="NAudio" Version="2.2.1" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
-		<PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
-		<PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+		<PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
+		<PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
+		<PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
 		<PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
-		<PackageReference Include="System.Runtime.Caching" Version="6.0.0" />
+		<PackageReference Include="System.Runtime.Caching" Version="10.0.3" />
 		<PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
 	</ItemGroup>
 

--- a/SRC.Sharp/SRCSharpFormTestWinAppDriver/packages.config
+++ b/SRC.Sharp/SRCSharpFormTestWinAppDriver/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Appium.WebDriver" version="8.1.0" targetFramework="net472" />
   <package id="Castle.Core" version="5.2.1" targetFramework="net472" />
@@ -6,18 +6,18 @@
   <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.3" targetFramework="net472" />
   <package id="MSTest.TestAdapter" version="3.1.1" targetFramework="net472" />
   <package id="MSTest.TestFramework" version="3.1.1" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net472" />
   <package id="Selenium.Support" version="4.41.0" targetFramework="net472" />
   <package id="Selenium.WebDriver" version="4.41.0" targetFramework="net472" />
   <package id="System.Buffers" version="4.6.1" targetFramework="net472" />
   <package id="System.Drawing.Common" version="10.0.3" targetFramework="net472" />
-  <package id="System.IO.Pipelines" version="9.0.9" targetFramework="net472" />
+  <package id="System.IO.Pipelines" version="10.0.3" targetFramework="net472" />
   <package id="System.Memory" version="4.6.3" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.6.1" targetFramework="net472" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net472" />
-  <package id="System.Text.Encodings.Web" version="9.0.9" targetFramework="net472" />
-  <package id="System.Text.Json" version="9.0.9" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="10.0.3" targetFramework="net472" />
+  <package id="System.Text.Json" version="10.0.3" targetFramework="net472" />
   <package id="System.Threading.Channels" version="10.0.3" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.6.3" targetFramework="net472" />
-  <package id="System.ValueTuple" version="4.6.1" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.6.2" targetFramework="net472" />
 </packages>

--- a/SRC.Sharp/SRCTestBlazor/SRCTestBlazor.csproj
+++ b/SRC.Sharp/SRCTestBlazor/SRCTestBlazor.csproj
@@ -13,12 +13,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Markdig" Version="1.0.0" />
+		<PackageReference Include="Markdig" Version="1.0.1" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.24" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.24" PrivateAssets="all" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="ShiftJISExtension" Version="1.1.0" />
-		<PackageReference Include="System.Net.Http.Json" Version="8.0.1" />
+		<PackageReference Include="System.Net.Http.Json" Version="10.0.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/SRC.Sharp/SRCTestForm/SRCTestForm.csproj
+++ b/SRC.Sharp/SRCTestForm/SRCTestForm.csproj
@@ -8,9 +8,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.3" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Microsoft.Extensions.Logging、Newtonsoft.Json、Serilog、System.Drawing.Common など主要な依存パッケージを最新バージョン（10.x系や13.0.4等）に更新しました。これによりセキュリティ向上やバグ修正、将来的な互換性の確保を図っています。packages.config も含め、全体的な依存関係のメンテナンスを実施しています。