### PR TITLE
HTTPストリームをMemoryStream化し例外処理を強化

### DIFF
--- a/SRC.Sharp/SRCCore/Models/NonPilotDataList.cs
+++ b/SRC.Sharp/SRCCore/Models/NonPilotDataList.cs
@@ -2,6 +2,7 @@
 // 本プログラムはフリーソフトであり、無保証です。
 // 本プログラムはGNU General Public License(Ver.3またはそれ以降)が定める条件の下で
 // 再頒布または改変することができます。
+using Newtonsoft.Json.Linq;
 using SRCCore.Extensions;
 using SRCCore.Lib;
 using SRCCore.VB;
@@ -28,6 +29,11 @@ namespace SRCCore.Models
             npd.Nickname = "ナレーター";
             npd.Bitmap = ".bmp";
             colNonPilotDataList.Add(npd, npd.Name);
+        }
+
+        public void Clear()
+        {
+            colNonPilotDataList.Clear();
         }
 
         // ノンパイロットデータリストにデータを追加

--- a/SRC.Sharp/SRCTestBlazor/Shared/LoadTitleView.razor
+++ b/SRC.Sharp/SRCTestBlazor/Shared/LoadTitleView.razor
@@ -45,6 +45,7 @@
 
         SRC.UDList.Clear();
         SRC.PDList.Clear();
+		SRC.NPDList.Clear();
         //SRC.MDList.Clear();
         //SRC.DDList.Clear();
         SRC.IDList.Clear();
@@ -65,6 +66,10 @@
                         break;
                     case "pilot.txt":
                         SRC.PDList.Load(file, await FetchAsMemoryStreamAsync($"{baseUri}/{file}"));
+                        Console.WriteLine($"{file} was loaded.");
+                        break;
+                    case "non_pilot.txt":
+                        SRC.NPDList.Load(file, await FetchAsMemoryStreamAsync($"{baseUri}/{file}"));
                         Console.WriteLine($"{file} was loaded.");
                         break;
                     case "pilot_message.txt":

--- a/SRC.Sharp/SRCTestBlazor/Shared/LoadTitleView.razor
+++ b/SRC.Sharp/SRCTestBlazor/Shared/LoadTitleView.razor
@@ -1,5 +1,6 @@
 ﻿@using System.Diagnostics;
-@using System.IO
+@using System.IO;
+@using System.Threading.Tasks
 
 <TitleView SRC="@SRC" DataTitle="@DataTitle" />
 <div id="status" class="message">@StatusText</div>
@@ -26,6 +27,15 @@
         await UpdateData();
     }
 
+    private async Task<MemoryStream> FetchAsMemoryStreamAsync(string url)
+    {
+        using var httpStream = await Http.GetStreamAsync(url);
+        var memoryStream = new MemoryStream();
+        await httpStream.CopyToAsync(memoryStream);
+        memoryStream.Position = 0;
+        return memoryStream;
+    }
+
     private async Task UpdateData()
     {
         StatusText = "Now Loading...";
@@ -50,23 +60,23 @@
                 {
                     case "unit.txt":
                     case "robot.txt":
-                        SRC.UDList.Load(file, await Http.GetStreamAsync($"{baseUri}/{file}"));
+                        SRC.UDList.Load(file, await FetchAsMemoryStreamAsync($"{baseUri}/{file}"));
                         Console.WriteLine($"{file} was loaded.");
                         break;
                     case "pilot.txt":
-                        SRC.PDList.Load(file, await Http.GetStreamAsync($"{baseUri}/{file}"));
+                        SRC.PDList.Load(file, await FetchAsMemoryStreamAsync($"{baseUri}/{file}"));
                         Console.WriteLine($"{file} was loaded.");
                         break;
                     case "pilot_message.txt":
-                        SRC.MDList.Load(file, false, await Http.GetStreamAsync($"{baseUri}/{file}"));
+                        SRC.MDList.Load(file, false, await FetchAsMemoryStreamAsync($"{baseUri}/{file}"));
                         Console.WriteLine($"{file} was loaded.");
                         break;
                     case "pilot_dialog.txt":
-                        SRC.DDList.Load(file, await Http.GetStreamAsync($"{baseUri}/{file}"));
+                        SRC.DDList.Load(file, await FetchAsMemoryStreamAsync($"{baseUri}/{file}"));
                         Console.WriteLine($"{file} was loaded.");
                         break;
                     case "item.txt":
-                        SRC.IDList.Load(file, await Http.GetStreamAsync($"{baseUri}/{file}"));
+                        SRC.IDList.Load(file, await FetchAsMemoryStreamAsync($"{baseUri}/{file}"));
                         Console.WriteLine($"{file} was loaded.");
                         break;
                     default:
@@ -74,7 +84,10 @@
                         break;
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Error loading file [{file}]: {ex.Message}");
+            }
         }
 
         sw.Stop();


### PR DESCRIPTION
FetchAsMemoryStreamAsyncを追加し、各データファイル読込時にMemoryStreamへ変換するよう修正。これによりストリームの再利用やシークが可能に。例外処理もcatch (Exception ex)に変更し、エラー内容をConsole.Errorに出力するよう改善。